### PR TITLE
Add support for arbitrary sections

### DIFF
--- a/ass/document.py
+++ b/ass/document.py
@@ -608,9 +608,11 @@ class Document(object):
     STYLE_SSA_HEADER = "V4 Styles"
     STYLE_ASS_HEADER = "V4+ Styles"
     EVENTS_HEADER = "Events"
+    AEGISUB_PROJECT_HEADER = "Aegisub Project Garbage"
 
     SECTIONS = CaseInsensitiveOrderedDict({
         SCRIPT_INFO_HEADER: ScriptInfoSection,
+        AEGISUB_PROJECT_HEADER: FieldSection,
         STYLE_SSA_HEADER: StylesSection,
         STYLE_ASS_HEADER: StylesSection,
         EVENTS_HEADER: EventsSection

--- a/tests/test.ass
+++ b/tests/test.ass
@@ -3,6 +3,23 @@ ScriptType: v4.00+
 PlayResX: 500
 PlayResY: 500
 
+[Aegisub Project Garbage]
+Audio File: video.mkv
+Video File: video.mkv
+Keyframes File: keyframes.txt
+Video AR Mode: 4
+Video AR Value: 1.777778
+Video Zoom Percent: 1.000000
+Scroll Position: 30
+Active Line: 20
+Video Position: 12000
+
+[Custom Section]
+Line: 1
+Line: 2
+Line: 3
+Another Line: 20
+
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,1,2,5,10,10,10,1
@@ -14,3 +31,6 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\an2}this is a line at \an2
 Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\an8}this is a line at \an8
 Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\an4}this is a line at \an4
 Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\an6}this is a line at \an6
+
+[Aegisub Extradata]
+Data: 0,a-mo,e{"uuid"#3A"111209fa-a66b-41a1-9e1a-2a94dde74a78"#2C"originalText"#3A"{\\fnMailart Rubberstamp\\fax0.19\\fs50\\fscx105\\blur0.6\\c&H6C8389&\\frz348.2\\pos(746.2#2C173.2)}Student Co{\\c&H6C8389&}u{*\\c&H73898F&}n{*\\c&H7B8F95&}c{*\\c&H82969B&}i{*\\c&H8A9CA1&}l {*\\c&H99A8AE&}R{*\\c&HA0AFB4&}o{*\\c&HA8B5BA&}o{\\c&HAFBBC0&}m"}


### PR DESCRIPTION
This pull requests adds support for parsing and dumping arbitrary sections, to ensure that all sections from the input file are left intact, including sections that python-ass doesn't understand. The refactoring also makes it easier to implement support for new types of sections, part of the motivation for which is that I later want to add proper support for parsing extradata.

Though the concept is simple, it required a surprising amount of refactoring, with a number of design decisions that had to be made. I don't necessarily expect the pull request to be accepted as is, but rather to serve as a basis for discussion on what a good design would be. I've tried to ensure that the changes are backwards compatible, at least for code that does not depend on implementation details.

Central to the redesign is a new attribute, `Document.sections`, which is a mapping from section name to section. Each section is represented as an instance of a corresponding section class. It was necessary to implement it this way as opposed to simply representing the sections as lists or dicts as appropriate, as the sections additionally need to store information such as the field order and how to dump the section.

Some notes:

* There are two base section classes, `LineSection` and `FieldSection`, with subclasses for more specialized sections (`EventsSection`, `StylesSection`, `ScriptInfoSection`). `LineSection` is used as the default for unsupported sections.
* `LineSection` can be treated as a list, `FieldSection` as a dict.
* `FieldSection` subclasses can specify how to parse values using the `FIELDS` attribute; doing this instead of using the `_WithFieldMeta` pattern was necessary in order to avoid the metaclass conflict that occurs from inheriting `collections.abc.MutableMapping` and having `_WithFieldMeta` as a metaclass. (Also, I felt like using _WithFieldMeta for non-line classes was kind of hacky to begin with, but YMMV.)
* `LineSection` subclasses can specify how to parse lines using the `LINE_PARSER` attribute. If no such attribute is specified, the new `Unknown` line type will be used, which has a single field `value` containing the raw line (not including the type name). If `LINE_PARSER` is present, a `ValueError` will be raised when encountering an unexpected line.
* Even for empty inputs, an empty `ScriptInfoSection`, `StylesSection` and `EventsSection` will be created to match the current behaviour.
* The attributes `events`, `styles` and `fields` point to the corresponding section objects in the `sections` mapping.
* The `sections` mapping is backed by an `OrderedDict` to ensure that the order of the sections is preserved when dumping the data.
* A new class `CaseInsensitiveOrderedDict` is included to simplify some existing case insensitive logic. (python-ass seems to in general assume that section names are case insensitive.) This also means that the user can access sections in `Document.sections` without worrying about casing.
* `_Line` can now take an optional `type_name` argument, which is used if the line class does not already specify a `TYPE` (this is specifically to support the new `Unknown` line type, which doesn't have a single fixed type name).
* Format lines are now optional, as not all sections will have one. (E.g. the extradata section, or any unsupported section.) If no format line is present, `EventsSection` and `StylesSection` will use a default format.
* With the current design it's not possible to simply reassign the `events`, `fields` or `styles` attributes in `Document`, and certainly not with plain lists/dicts.
* `FieldSection` sections do not currently support aliases (e.g. a `script_type` attribute being mapped to the `ScriptType` value), due to the aforementioned metaclass conflict, as well as me not really seeing the value in it. There are aliases present in `Document` though, for backwards compatibility.

As a demonstration, this pull request additionally includes a small commit adding support for the "Aegisub Project Garbage" section.