### PR TITLE
Expose parse_string and parse_file at top-level

### DIFF
--- a/ass/__init__.py
+++ b/ass/__init__.py
@@ -10,4 +10,6 @@ __all__ = [
     "parse",
 ]
 
-parse = document.Document.parse_file
+parse_file = document.Document.parse_file
+parse_string = document.Document.parse_string
+parse = parse_file


### PR DESCRIPTION
I use parse_string way more often than parse_file, so I would suggest this change :) 