### PR TITLE
Add missing justify int field to renderer.Style

### DIFF
--- a/src/ass/renderer.py
+++ b/src/ass/renderer.py
@@ -281,7 +281,8 @@ class Style(ctypes.Structure):
         ("margin_v", ctypes.c_int),
         ("encoding", ctypes.c_int),
         ("treat_fontname_as_pattern", ctypes.c_int),
-        ("blur", ctypes.c_double)
+        ("blur", ctypes.c_double),
+        ("justify", ctypes.c_int)
     ]
 
     @staticmethod


### PR DESCRIPTION
libass added an extra [int Justify to ASS_Style](https://github.com/libass/libass/blob/master/libass/ass_types.h#L132), so  the `renderer.Style` definition was out of sync with the C library. This caused rendering with any style other than Default to not work and SEFAULTs. This should fix it.

