### PR TITLE
tests: ensure correct PYTHONPATH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,8 @@ dev = [
 [build-system]
 requires = ["uv_build>=0.8.22,<0.9.0"]
 build-backend = "uv_build"
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]


### PR DESCRIPTION
Moving the files to a `src/` directory (adf57695c07929426be3087987e69a7272cf0422) means pytest can't find them and will use the system-installed version of the package (or crash if there isn't one) instead of the source tree. This can be fixed telling pytest to look in `src/`.
 
https://stackoverflow.com/questions/10253826/path-issue-with-pytest-importerror-no-module-named