### PR TITLE
Fix parsing of boolean values in style lines

### DIFF
--- a/src/ass/data.py
+++ b/src/ass/data.py
@@ -98,6 +98,9 @@ class _Field(object):
             return ""
 
         if isinstance(v, bool):
+            # Mimics behavior of booleans in styles,
+            # not that of field sections
+            # where "yes" and "no" would be more appropriate.
             return str(-int(v))
 
         if isinstance(v, timedelta):

--- a/src/ass/line.py
+++ b/src/ass/line.py
@@ -80,6 +80,18 @@ class Unknown(_Line):
     value = _Field("Value", str, default="")
 
 
+def _parse_bool_in_style(s: str) -> bool:
+    """Booleans in styles are parsed as integers and compared against 0.
+
+    This is unlike the normal "parse_bool" behavior.
+    It would probably be more sane to parse these as ints,
+    but that would be a breaking change to our API.
+
+    https://github.com/libass/libass/blob/534a5f8299c5ab3c2782856fcb843bfea47b7afc/libass/ass.c#L602-L605
+    """
+    return int(s) != 0
+
+
 class Style(_Line):
     """ A style line in ASS.
     """
@@ -92,10 +104,10 @@ class Style(_Line):
     secondary_color = _Field("SecondaryColour", Color, default=Color.RED)
     outline_color = _Field("OutlineColour", Color, default=Color.BLACK)
     back_color = _Field("BackColour", Color, default=Color.BLACK)
-    bold = _Field("Bold", bool, default=False)
-    italic = _Field("Italic", bool, default=False)
-    underline = _Field("Underline", bool, default=False)
-    strike_out = _Field("StrikeOut", bool, default=False)
+    bold = _Field("Bold", _parse_bool_in_style, default=False)
+    italic = _Field("Italic", _parse_bool_in_style, default=False)
+    underline = _Field("Underline", _parse_bool_in_style, default=False)
+    strike_out = _Field("StrikeOut", _parse_bool_in_style, default=False)
     scale_x = _Field("ScaleX", float, default=100)
     scale_y = _Field("ScaleY", float, default=100)
     spacing = _Field("Spacing", float, default=0)

--- a/tests/test.ass
+++ b/tests/test.ass
@@ -23,6 +23,7 @@ Another Line: 20
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,1,2,5,10,10,10,1
+Style: Alternative,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,-1,-1,-1,-1,100,100,0,0,1,2,2,2,10,10,10,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text

--- a/tests/test.ass
+++ b/tests/test.ass
@@ -2,6 +2,9 @@
 ScriptType: v4.00+
 PlayResX: 500
 PlayResY: 500
+WrapStyle: 0
+ScaledBorderAndShadow: yes
+YCbCr Matrix: None
 
 [Aegisub Project Garbage]
 Audio File: video.mkv

--- a/tests/test_ass.py
+++ b/tests/test_ass.py
@@ -79,9 +79,22 @@ class TestSections:
         assert copy["Arbitrary Field"] == "hi"
         assert doc.play_res_x == 500
 
-    @pytest.mark.skip("Unimplemented")
-    def test_styles(self):
-        pass
+    def test_styles(self, example_doc):
+        assert len(example_doc.styles) == 2
+        default_style, alternative_style = example_doc.styles
+
+        assert default_style.name == "Default"
+        assert alternative_style.name == "Alternative"
+
+        assert default_style.bold is False
+        assert default_style.italic is False
+        assert default_style.underline is False
+        assert default_style.strike_out is False
+
+        assert alternative_style.bold is True
+        assert alternative_style.italic is True
+        assert alternative_style.underline is True
+        assert alternative_style.strike_out is True
 
     @pytest.mark.skip("Unimplemented")
     def test_events(self):


### PR DESCRIPTION
Style lines use "-1" for a "truthy" value. libass parses these as
integers instead of booleans, but for the sake of
backwards-compatibility we stick to the boolean and just use a
different parsing method.

Fixes #28