### PR TITLE
Allow manipulation of comments in the Script Info section

### DIFF
--- a/src/ass/document.py
+++ b/src/ass/document.py
@@ -93,7 +93,7 @@ class Document(object):
             if not line:
                 continue
 
-            if line.startswith(';'): 
+            if line.startswith(';'):
                 # ";" comments only permitted in Script Info section, ignore otherwise
                 if section == doc.sections.get("Script Info"):
                     section.add_comment(line[1:])

--- a/src/ass/document.py
+++ b/src/ass/document.py
@@ -90,7 +90,13 @@ class Document(object):
                                      " usually '%s'" % cls.PREFERRED_ENCODING.name)
 
             line = line.strip()
-            if not line or line.startswith(';'):
+            if not line:
+                continue
+
+            if line.startswith(';'): 
+                # ";" comments only permitted in Script Info section, ignore otherwise
+                if section == doc.sections.get("Script Info"):
+                    section.add_comment(line[1:])
                 continue
 
             if line.startswith('[') and line.endswith(']'):

--- a/src/ass/section.py
+++ b/src/ass/section.py
@@ -84,6 +84,11 @@ class FieldSection(abc.MutableMapping):
     def dump(self):
         yield "[{}]".format(self.name)
 
+        # Comments are customarily at the beginning
+        if hasattr(self, "comments"):
+            for c in self.comments:
+                yield ";{}".format(c)
+
         for k, v in self._fields.items():
             yield "{}: {}".format(k, _Field.dump(v))
 
@@ -149,3 +154,10 @@ class ScriptInfoSection(FieldSection):
         "WrapStyle": _Field("WrapStyle", int, default=0),
         "ScaledBorderAndShadow": _Field("ScaledBorderAndShadow", str, default="yes")
     }
+
+    def add_comment(self, comment):
+        self.comments.append(comment)
+
+    def __init__(self, name, fields=None):
+        super().__init__(name, fields=fields)
+        self.comments = []


### PR DESCRIPTION
The idea here is that a user of this library should have the ability to add Script Info comments to an ass document. When parsing a file, they are also preserved. It may make more sense to allow them in any section, but as I understand it the spec only mentions ";" comments to be available in Script Info so that is all that is implemented here. The existing functionality of ignoring lines starting with ";" in other sections is maintained.

Note that while this retains the order of the comments, it will always put them in their customary position at the beginning of the Script Info, before any of the fields, rather than tracking any position they could have interleaved between the field lines. This means they can't be used as comments for particular fields, but I don't think that was ever an intended use case of these comments anyway.