### PR TITLE
Provide more information/context in exceptions

### DIFF
--- a/src/ass/data.py
+++ b/src/ass/data.py
@@ -26,7 +26,7 @@ class Color(object):
         """ Convert a Visual Basic (ASS) color code into an ``Color``.
         """
         if not v.startswith("&H"):
-            raise ValueError("color must start with &H")
+            raise ValueError("color must start with &H (found '%s')" % v)
 
         rest = int(v[2:], 16)
 

--- a/src/ass/document.py
+++ b/src/ass/document.py
@@ -82,14 +82,14 @@ class Document(object):
 
         section = None
         seen_sections = CaseInsensitiveOrderedDict()
-        for i, line in enumerate(f):
+        for i, raw_line in enumerate(f):
             if i == 0:
                 bom_seqeunces = ("\xef\xbb\xbf", "\xff\xfe", "\ufeff")
-                if any(line.startswith(seq) for seq in bom_seqeunces):
+                if any(raw_line.startswith(seq) for seq in bom_seqeunces):
                     raise ValueError("BOM detected. Please open the file with the proper encoding,"
                                      " usually '%s'" % cls.PREFERRED_ENCODING.name)
 
-            line = line.strip()
+            line = raw_line.strip()
             if not line or line.startswith(';'):
                 continue
 
@@ -105,7 +105,7 @@ class Document(object):
                 continue
 
             if section is None:
-                raise ValueError('Content outside of any section.')
+                raise ValueError("Content outside of any section\n\n%d:%s" % (i+1, raw_line))
 
             if ':' not in line:
                 # illformed, ignore
@@ -113,7 +113,10 @@ class Document(object):
 
             type_name, _, line = line.partition(":")
             line = line.lstrip()
-            section.add_line(type_name, line)
+            try:
+                section.add_line(type_name, line)
+            except Exception as e:
+                raise type(e)("Failed to parse file\n\n%d:%s" % (i+1, raw_line)) from e
 
         # append default sections not present in the parsed file
         for section_name, section in doc.sections.items():

--- a/src/ass/section.py
+++ b/src/ass/section.py
@@ -36,7 +36,7 @@ class LineSection(abc.MutableSequence):
             self.field_order = [field.strip() for field in raw_line.split(",")]
         else:
             if self.line_parsers is not None and type_name.lower() not in self.line_parsers:
-                raise ValueError("unexpected {} line in {}".format(type_name, self.name))
+                raise ValueError("unexpected '{}' line in {}".format(type_name, self.name))
 
             parser = (self.line_parsers[type_name.lower()]
                       if self.line_parsers is not None


### PR DESCRIPTION
Currently, many of the exception messages do not provide specifics about the error. This PR adds line number and contents to exceptions from Document.parse_file, and improves some additional exception messages.