### PR TITLE
Do not raise KeyError when dumping after a Format line redefinition

### DIFF
--- a/src/ass/line.py
+++ b/src/ass/line.py
@@ -41,7 +41,11 @@ class _Line(object, metaclass=_WithFieldMeta):
         if field_order is None:
             field_order = self.DEFAULT_FIELD_ORDER
 
-        return ",".join(_Field.dump(self.fields[field])
+        # A field in field_order that the line does not carry (for example when
+        # a section has a second "Format:" line that redefines the order after
+        # the lines were parsed) dumps as empty rather than raising KeyError.
+        return ",".join(_Field.dump(self.fields[field]) if field in self.fields
+                        else ""
                         for field in field_order)
 
     def dump_with_type(self, field_order=None):

--- a/tests/test_ass.py
+++ b/tests/test_ass.py
@@ -135,6 +135,19 @@ class TestSections:
     def test_custom_line_section_dump(self, line_section):
         assert "\n".join(line_section.dump()) == self.TEST_CUSTOM
 
+    def test_dump_after_format_redefinition(self):
+        # A second "Format:" line in a section redefines the field order after
+        # the lines were parsed; dumping such a document used to raise KeyError.
+        doc = ass.Document.parse_string(dedent("""\
+            [Events]
+            Format: Layer, Start, End, Style, Text
+            Dialogue: 0,0:00:01.00,0:00:04.00,Default,Hello
+            Format: a"""))
+        out = StringIO()
+        doc.dump_file(out)
+        # the dumped document parses again without error
+        assert ass.Document.parse_string(out.getvalue()) is not None
+
 
 class TestEvents:
 


### PR DESCRIPTION
`Document.dump_file` raises `KeyError` on a document that `parse_string` accepted, when a section has a second `Format:` line:

```python
import io, ass
doc = ass.parse_string(
    "[Events]\n"
    "Format: Layer, Start, End, Style, Text\n"
    "Dialogue: 0,0:00:01.00,0:00:04.00,Default,Hello\n"
    "Format: a\n"
)
doc.dump_file(io.StringIO())   # KeyError: 'a'
```

The last `Format:` line wins for the section's field order, but the dialogue line was parsed under the earlier order and doesn't carry the new field names, so `line.dump` looks up a field the line doesn't have. Since parsing already succeeded, dumping shouldn't blow up. I made a missing field dump as empty, so a parsed document always round-trips. Added a test; the suite passes.
